### PR TITLE
v2.3.1

### DIFF
--- a/Arma3ObjectBuilder/CHANGELOG.md
+++ b/Arma3ObjectBuilder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.3.1](https://github.com/MrClock8163/Arma3ObjectBuilder/releases/tag/v2.3.1) (Blender 2.90 -> 4.1)
+
+### Fixed
+
+- Sort Sections P3D export option was operating on the wrong object, and wasn't actually affecting the output model
+
 ## [v2.3.0](https://github.com/MrClock8163/Arma3ObjectBuilder/releases/tag/v2.3.0) (Blender 2.90 -> 4.1)
 
 ### Added

--- a/Arma3ObjectBuilder/__init__.py
+++ b/Arma3ObjectBuilder/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Arma 3 Object Builder",
     "description": "Collection of tools for editing Arma 3 content",
     "author": "MrClock (present add-on), Hans-Joerg \"Alwarren\" Frieden (original ArmaToolbox add-on)",
-    "version": (2, 3, 0),
+    "version": (2, 3, 1, "dev"),
     "blender": (2, 90, 0),
     "location": "Object Builder panels",
     "warning": "Development",

--- a/Arma3ObjectBuilder/__init__.py
+++ b/Arma3ObjectBuilder/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Arma 3 Object Builder",
     "description": "Collection of tools for editing Arma 3 content",
     "author": "MrClock (present add-on), Hans-Joerg \"Alwarren\" Frieden (original ArmaToolbox add-on)",
-    "version": (2, 3, 1, "dev"),
+    "version": (2, 3, 1),
     "blender": (2, 90, 0),
     "location": "Object Builder panels",
     "warning": "Development",

--- a/Arma3ObjectBuilder/io/export_p3d.py
+++ b/Arma3ObjectBuilder/io/export_p3d.py
@@ -371,7 +371,7 @@ def get_lod_data(operator, context, validator, temp_collection):
         # community wiki: https://community.bistudio.com/wiki/Section_Count.
         # Some corrections: https://mrcmodding.gitbook.io/home/documents/sections.
         if operator.sort_sections:
-            sort_sections(obj)
+            sort_sections(main_obj)
         
         for copy, is_valid_copy in zip(main_obj.a3ob_properties_object.copies, is_valid_copies):
             main_obj_copy = duplicate_object(main_obj, temp_collection)


### PR DESCRIPTION
### Fixed

- Sort Sections P3D export option was operating on the wrong object, and wasn't actually affecting the output model